### PR TITLE
Updating version of Ruby and corresponding Gemfile.lock

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 # A sample Gemfile
 source "https://rubygems.org"
-ruby "~> 3.1.0"
+ruby "~> 3.4.2"
 
 gem "oauth2", "~> 1.4.0"
 gem "slack-notifier"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,16 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    addressable (2.8.7)
+      public_suffix (>= 2.0.2, < 7.0)
+    bigdecimal (3.1.9)
+    crack (1.0.0)
+      bigdecimal
+      rexml
+    diff-lcs (1.6.1)
     faraday (1.0.1)
       multipart-post (>= 1.2, < 3)
+    hashdiff (1.1.2)
     jwt (2.2.2)
     multi_json (1.15.0)
     multi_xml (0.6.0)
@@ -13,18 +21,39 @@ GEM
       multi_json (~> 1.3)
       multi_xml (~> 0.5)
       rack (>= 1.2, < 3)
+    public_suffix (6.0.2)
     rack (2.2.9)
+    rexml (3.4.1)
+    rspec (3.13.0)
+      rspec-core (~> 3.13.0)
+      rspec-expectations (~> 3.13.0)
+      rspec-mocks (~> 3.13.0)
+    rspec-core (3.13.3)
+      rspec-support (~> 3.13.0)
+    rspec-expectations (3.13.3)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.13.0)
+    rspec-mocks (3.13.2)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.13.0)
+    rspec-support (3.13.2)
     slack-notifier (1.4.0)
+    webmock (3.25.1)
+      addressable (>= 2.8.0)
+      crack (>= 0.3.2)
+      hashdiff (>= 0.4.0, < 2.0.0)
 
 PLATFORMS
-  ruby
+  x86_64-linux
 
 DEPENDENCIES
   oauth2 (~> 1.4.0)
+  rspec
   slack-notifier
+  webmock
 
 RUBY VERSION
-   ruby 3.1.0
+   ruby 3.4.2p28
 
 BUNDLED WITH
-   2.4.10
+   2.6.6


### PR DESCRIPTION
## Changes proposed in this pull request:
- Gemfile.lock needs to be updated, this was done from the staging jumpbox with `bundle install`, the jumpbox is running ruby 3.4.2
- Part of https://github.com/cloud-gov/sandbox-bot/issues/77
-

## security considerations
Updates to newer Ruby version
