### PR TITLE
Adding base64 gem, no longer part of standard library

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,7 @@
 source "https://rubygems.org"
 ruby "~> 3.4.2"
 
+gem "base64"
 gem "oauth2", "~> 1.4.0"
 gem "slack-notifier"
 gem "rspec"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,6 +3,7 @@ GEM
   specs:
     addressable (2.8.7)
       public_suffix (>= 2.0.2, < 7.0)
+    base64 (0.2.0)
     bigdecimal (3.1.9)
     crack (1.0.0)
       bigdecimal
@@ -47,6 +48,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  base64
   oauth2 (~> 1.4.0)
   rspec
   slack-notifier


### PR DESCRIPTION
## Changes proposed in this pull request:
- App was crashing with:

```
2025-04-30T14:36:31.98-0400 [APP/PROC/WEB/0] ERR /home/vcap/deps/0/ruby/lib/ruby/3.4.0/did_you_mean/core_ext/name_error.rb:11: warning: base64 is not part of the default gems starting from Ruby 3.4.0. Install base64 from RubyGems.
```
- Found that as of Ruby 3.4.0 the `base64` functions are no longer part of the standard library
- Adding `base64` gem to the Gemfile and Gemfile.lock.  Odd that it worked fine from the jumpbox so 🤷 
- Part of https://github.com/cloud-gov/sandbox-bot/issues/77

## security considerations
None, adding a gem
