### PR TITLE
Adding acceptance tests to prod

### DIFF
--- a/ci/acceptance-tests.sh
+++ b/ci/acceptance-tests.sh
@@ -63,13 +63,6 @@ SPACE_NAMES=("test.user" "test.user2")
 echo "Logging into ${CF_API} as user ${CF_ADMIN_USER}..."
 cf login -a ${CF_API} -u ${CF_ADMIN_USER} -p "${CF_ADMIN_PASSWORD}" -o cloud-gov -s bots >/dev/null 2>&1
 
-# Confirm that we're targeting the correct API
-api_target=$(cf api | grep -i 'API endpoint' | awk '{print $3}')
-if [[ "$api_target" != *"fr-stage"* ]]; then
-  echo "Error: Not targeting staging. Current API endpoint: $api_target, exiting for your own safety."
-  exit 1
-fi
-
 # Cleanup from a previous run in case it errored out
 cleanup_sandbox_resources
 
@@ -229,13 +222,6 @@ echo "🎯 Finished all checks."
 
 ## Clean up users
 echo "Cleaning up resources from the test..."
-
-# Confirm that we're targeting the correct API
-api_target=$(cf api | grep -i 'API endpoint' | awk '{print $3}')
-if [[ "$api_target" != *"fr-stage"* ]]; then
-  echo "Error: Not targeting staging. Current API endpoint: $api_target, exiting for your own safety."
-  exit 1
-fi
 
 cleanup_sandbox_resources
 

--- a/ci/acceptance-tests.yml
+++ b/ci/acceptance-tests.yml
@@ -15,4 +15,4 @@ inputs:
 
 
 run:
-  path: git-sandbox-bot/ci/staging-acceptance-tests.sh
+  path: git-sandbox-bot/ci/acceptance-tests.sh

--- a/ci/config.yml
+++ b/ci/config.yml
@@ -5,3 +5,5 @@ cf-organization: cloud-gov
 cf-space: bots
 cf-api-staging: api.fr-stage.cloud.gov
 admin-user-staging: sandbox-bot-user
+cf-api-production: api.fr.cloud.gov
+admin-user-production: sandbox-bot-user

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -144,7 +144,7 @@ jobs:
       passed: [deploy-sandbox-bot-stage]
       trigger: true
   - task: sandbox-bot-stage-acceptance-tests
-    file: git-sandbox-bot/ci/staging-acceptance-tests.yml
+    file: git-sandbox-bot/ci/acceptance-tests.yml
     params:
       CF_API: ((cf-api-staging))
       CF_ADMIN_USER: ((admin-user-staging))
@@ -201,3 +201,28 @@ jobs:
       text: |
         :white_check_mark: Successfully deployed $BUILD_PIPELINE_NAME on ((prod-cf-api-url))
         <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
+
+
+- name: run-sandbox-bot-prod-acceptance-tests
+  serial: true
+  serial_groups:
+  - sandbox-bot
+  plan:
+  - in_parallel:
+    - get: git-sandbox-bot
+      passed: [deploy-sandbox-bot-prod]
+      trigger: true
+  - task: sandbox-bot-prod-acceptance-tests
+    file: git-sandbox-bot/ci/acceptance-tests.yml
+    params:
+      CF_API: ((cf-api-production))
+      CF_ADMIN_USER: ((admin-user-production))
+      CF_ADMIN_PASSWORD: ((admin-password-production))
+  on_failure:
+    put: slack
+    params:
+      <<: *slack-failure-params
+      text: |
+        :x: FAILED to run staging acceptance tests $BUILD_PIPELINE_NAME on ((staging-cf-api-url))
+        <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
+ 


### PR DESCRIPTION
## Changes proposed in this pull request:
- Add a new job step to run the acceptance tests in production
- Renamed the test files to remove the name "staging" as they can be used in either env
- Removed the API url check logic, not needed since there are separate logins for prod versus stage, is also safe to run in prod because the agency org used doesn't exist
- This should be the last part of https://github.com/cloud-gov/sandbox-bot/issues/77

## security considerations
Passwords are stored in credhub, uses a fake gov't agency using the email domain `test.gov`, no other changes to the security boundary
