### PR TITLE
Mouse trap - Scan sandboxes for applications in CF Staging

### DIFF
--- a/ci/check-for-sandbox-apps.sh
+++ b/ci/check-for-sandbox-apps.sh
@@ -3,7 +3,7 @@
 set -uo pipefail
 
 # Purpose
-# Check for the presence of any applications currently deployed to 
+# Check for the presence of any applications currently deployed to a sandbox org in CF.  If an app is found, the org, space and app name are printed and exits non-zero.
 
 # Log into CF as an admin
 echo "Logging into ${CF_API} as user ${CF_ADMIN_USER}..."

--- a/ci/check-for-sandbox-apps.sh
+++ b/ci/check-for-sandbox-apps.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+set -uo pipefail
+
+# Purpose
+# Check for the presence of any applications currently deployed to 
+
+# Log into CF as an admin
+echo "Logging into ${CF_API} as user ${CF_ADMIN_USER}..."
+cf login -a ${CF_API} -u ${CF_ADMIN_USER} -p "${CF_ADMIN_PASSWORD}" -o cloud-gov -s bots >/dev/null 2>&1
+
+total_apps=0
+output_lines=()
+
+# Use the CF CLI since that has pagination built in, cf curl is a pain to loop in bash for pagination
+org_names=$(cf orgs | tail -n +2)
+
+while IFS= read -r org_name; do
+  # Only process orgs starting with 'sandbox-'
+  if [[ $org_name != sandbox-* ]]; then
+    continue
+  fi
+
+  echo "Scanning sandbox ${org_name}..."
+  org_guid=$(cf org "$org_name" --guid)
+
+  # Get spaces in the org
+  while IFS="|" read -r space_guid space_name; do
+    # Get apps in the space
+    apps=$(cf curl "/v3/apps?space_guids=$space_guid" | jq -r '.resources[].name')
+
+    if [[ -n "$apps" ]]; then
+      while IFS= read -r app_name; do
+        echo "Application ${app_name} found in organization ${org_name} and space ${space_name}"
+        output_lines+=("\"$org_name\",\"$space_name\",\"$app_name\"")
+        ((total_apps++))
+      done <<< "$apps"
+    fi
+  done < <(cf curl "/v3/spaces?organization_guids=$org_guid" | jq -r '.resources[] | "\(.guid)|\(.name)"')
+done <<< "$org_names"
+
+echo ""
+echo "Results:"
+# Print results
+if (( total_apps > 0 )); then
+  echo "Applications were found in:"
+  printf "%s\n" "${output_lines[@]}"
+  exit 1
+else
+  echo "No apps found in sandbox organizations. Carry on!"
+  exit 0
+fi

--- a/ci/check-for-sandbox-apps.yml
+++ b/ci/check-for-sandbox-apps.yml
@@ -1,0 +1,18 @@
+---
+platform: linux
+
+image_resource:
+  type: registry-image
+  source:
+    aws_access_key_id: ((ecr_aws_key))
+    aws_secret_access_key: ((ecr_aws_secret))
+    repository: general-task
+    aws_region: us-gov-west-1
+    tag: latest   
+
+inputs:
+- name: git-sandbox-bot
+
+
+run:
+  path: git-sandbox-bot/ci/check-for-sandbox-apps.sh

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -39,10 +39,10 @@ resources:
     skip_cert_check: false
 
 
-- name: hourly-timer
+- name: timer
   type: time
   source:
-    interval: 1h
+    interval: 4h
 
 resource_types:
 - name: registry-image
@@ -173,7 +173,7 @@ jobs:
     - get: git-sandbox-bot
       passed: [deploy-sandbox-bot-stage]
       trigger: true
-    - get: hourly-timer
+    - get: timer
       trigger: true
   - task: sandbox-bot-stage-look-for-sandbox-apps
     file: git-sandbox-bot/ci/check-for-sandbox-apps.yml

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -4,7 +4,7 @@ resources:
   type: git
   source:
     uri: https://github.com/cloud-gov/cg-sandbox-bot
-    branch: mouse-trap #main
+    branch: main
     commit_verification_keys: ((cloud-gov-pgp-keys))
 
 - name: dotgov-domain-data
@@ -137,15 +137,7 @@ jobs:
       channel: ((slack-failure-channel))
       username: ((slack-user.username))
       icon_url: ((slack-icon-url))
-  on_success: &slack-success-params
-    put: slack
-    params:
-      text: |
-        :white_check_mark: Successfully deployed $BUILD_PIPELINE_NAME on ((staging-cf-api-url))
-        <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
-      channel: ((slack-success-channel))
-      username: ((slack-user.username))
-      icon_url: ((slack-icon-url))
+
 
 
 - name: run-sandbox-bot-stage-acceptance-tests
@@ -234,13 +226,6 @@ jobs:
       <<: *slack-failure-params
       text: |
         :x: FAILED to deploy $BUILD_PIPELINE_NAME on ((prod-cf-api-url))
-        <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
-  on_success:
-    put: slack
-    params:
-      <<: *slack-success-params
-      text: |
-        :white_check_mark: Successfully deployed $BUILD_PIPELINE_NAME on ((prod-cf-api-url))
         <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
 
 

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -4,7 +4,7 @@ resources:
   type: git
   source:
     uri: https://github.com/cloud-gov/cg-sandbox-bot
-    branch: main
+    branch: mouse-trap #main
     commit_verification_keys: ((cloud-gov-pgp-keys))
 
 - name: dotgov-domain-data
@@ -158,6 +158,29 @@ jobs:
         <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
  
 
+- name: stage-look-for-sandbox-apps
+  serial: true
+  serial_groups:
+  - sandbox-bot
+  plan:
+  - in_parallel:
+    - get: git-sandbox-bot
+      passed: [deploy-sandbox-bot-stage]
+      trigger: true
+  - task: sandbox-bot-stage-look-for-sandbox-apps
+    file: git-sandbox-bot/ci/check-for-sandbox-apps.yml
+    params:
+      CF_API: ((cf-api-staging))
+      CF_ADMIN_USER: ((admin-user-staging))
+      CF_ADMIN_PASSWORD: ((admin-password-staging))
+  on_failure:
+    put: slack
+    params:
+      <<: *slack-failure-params
+      text: |
+        :x: There are apps in at least one sandbox org in CF Staging, review $BUILD_PIPELINE_NAME on ((staging-cf-api-url)) for the application, organization and space names.
+        <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
+ 
 
 - name: deploy-sandbox-bot-prod
   serial: true

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -192,11 +192,13 @@ jobs:
   on_failure:
     put: slack
     params:
-      <<: *slack-failure-params
       text: |
-        :x: There are apps in at least one sandbox org in CF Staging, review $BUILD_PIPELINE_NAME on ((staging-cf-api-url)) for the application, organization and space names.
+        :x: There are apps in at least one sandbox org in CF Staging, review $BUILD_PIPELINE_NAME for the application, organization and space names.
         <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
- 
+      channel: "#cg-platform"
+      username: ((slack-username))
+      icon_url: ((slack-icon-url))
+
 
 - name: deploy-sandbox-bot-prod
   serial: true

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -39,6 +39,11 @@ resources:
     skip_cert_check: false
 
 
+- name: hourly-timer
+  type: time
+  source:
+    interval: 1h
+
 resource_types:
 - name: registry-image
   type: registry-image
@@ -74,6 +79,15 @@ resource_types:
     aws_access_key_id: ((ecr_aws_key))
     aws_secret_access_key: ((ecr_aws_secret))
     repository: cf-resource
+    aws_region: us-gov-west-1
+    tag: latest
+
+- name: time
+  type: registry-image
+  source:
+    aws_access_key_id: ((ecr_aws_key))
+    aws_secret_access_key: ((ecr_aws_secret))
+    repository: time-resource
     aws_region: us-gov-west-1
     tag: latest
 
@@ -166,6 +180,8 @@ jobs:
   - in_parallel:
     - get: git-sandbox-bot
       passed: [deploy-sandbox-bot-stage]
+      trigger: true
+    - get: hourly-timer
       trigger: true
   - task: sandbox-bot-stage-look-for-sandbox-apps
     file: git-sandbox-bot/ci/check-for-sandbox-apps.yml


### PR DESCRIPTION
## Changes proposed in this pull request:
- Add a new job to scan for running application in CF Staging sandbox orgs, if found, send a Slack alert
- Fixed credhub value for `slack-user.username`, Slack messages from the pipeline for this repo now work
- Removed on_sucess slack messages as part of our ongoing efforts to remove these
- Part of https://github.com/cloud-gov/private/issues/2464

## security considerations
No new secrets leveraged, only runs against Staging and is non-blocking
